### PR TITLE
GitHub Actions のビルドワークフローで、Hugo のバージョンが v0.115.0 になったらビルド時にエラーが出るようになったので、一旦 v0.114.1 に固定

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.114.1
     steps:
       - name: Hugo のインストール
-        run: sudo snap install hugo
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Dart Sass のインストール
         run: sudo snap install dart-sass


### PR DESCRIPTION
Hugo のバージョンが v0.115.0 になったらビルド時にエラーが出るようになったので、一旦 v0.114.1 に固定します。

バージョンを固定したインストールの例は Hugo の公式ドキュメントにあったので、それをそのまま使います（Snappy でもできる気がするけど）: https://gohugo.io/hosting-and-deployment/hosting-on-github/